### PR TITLE
feat: Add assertion utility for input validation in Node class

### DIFF
--- a/src/dom/node.hpp
+++ b/src/dom/node.hpp
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <utility>
 
+#include "utils/assertion.hpp"
 #include "utils/html_tokens.hpp"
 
 namespace arboris {
@@ -52,17 +53,17 @@ class Node {
   }
 
   inline void set_out(std::uint32_t out) {
-    // TODO(Jayden): Call assertion here
+    ARBORIS_ASSERT(out > 0, "out must be greater than 0. got " << out);
     out_ = out;
   }
 
   inline void set_in(std::uint32_t in) {
-    // TODO(Jayden): Call assertion here
+    ARBORIS_ASSERT(in > 0, "in must be greater than 0. got " << in);
     in_ = in;
   }
 
   inline void set_text_content(std::string_view text_content) {
-    // TODO(Jayden): Call assertion here
+    ARBORIS_ASSERT(!text_content.empty(), "text_content must not be empty.");
     text_content_ = text_content;
   }
 

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -1,0 +1,30 @@
+/*
+ *   Copyright 2025 Team Arboris
+ *   Licensed under the Apache License, Version 2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef SRC_UTILS_ASSERTION_HPP_
+#define SRC_UTILS_ASSERTION_HPP_
+
+#if defined(DEBUG)
+#include <iostream>
+#endif
+
+#if defined(DEBUG)
+#define ARBORIS_ASSERT(cond, msg)                            \
+  do {                                                       \
+    if (!(cond)) {                                           \
+      std::cerr << "Assertion failed: " << std::endl         \
+                << " - condition : " << #cond << std::endl \
+                << " - message   : " << msg << std::endl   \
+                << " - at        : " << __FILE__ << ":" << __LINE__ << " in " << __func__ << std::endl; \
+      std::abort(); \
+    } \
+  } \
+  while (0)
+#else
+#define ARBORIS_ASSERT(cond, msg)
+#endif
+
+#endif  // SRC_UTILS_ASSERTION_HPP_


### PR DESCRIPTION
- Introduced ARBORIS_ASSERT macro for runtime assertions in debug mode.
- Replaced TODO comments in Node class methods with assertions to validate input parameters (out, in, text_content).
- Added new assertion.hpp file to define the assertion macro.