### PR TITLE
jack/tag-provider-string-test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,10 +2,14 @@ function(add_gtest name)
   add_executable(${name} ${ARGN})
   target_link_libraries(${name}
     PRIVATE
-      gtest
-      gtest_main
+    gtest
+    gtest_main
+    arboris
   )
+  target_include_directories(${name} PRIVATE ${CMAKE_SOURCE_DIR}/src)
   add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
 add_gtest(example_test example_test.cc)
+add_gtest(string_test string_test.cc)
+add_gtest(html_tag_provider_test html_tag_provider_test.cc)

--- a/tests/html_tag_provider_test.cc
+++ b/tests/html_tag_provider_test.cc
@@ -1,0 +1,475 @@
+/*
+ *   Copyright 2025 Team Arboris
+ *   Licensed under the Apache License, Version 2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "dom/html_tag_provider.hpp"
+#include "utils/html_tokens.hpp"
+#include "utils/tag.hpp"
+
+namespace arboris {
+namespace {
+
+// test data
+constexpr std::string_view kEmptyString = "";
+constexpr std::string_view kSimpleTag = "<div></div>";
+constexpr std::string_view kTagWithText = "<p>Hello World</p>";
+constexpr std::string_view kNestedTags = "<div><span>nested</span></div>";
+constexpr std::string_view kVoidTag = "<br>";
+constexpr std::string_view kMultipleVoidTags = "<br><img><input>";
+constexpr std::string_view kTagWithAttributes = "<div class='test' id='main'>content</div>";
+constexpr std::string_view kComplexHtml = "<html><head><title>Test</title></head><body><div>Hello</div></body></html>";
+
+// test data for edge cases and error conditions
+constexpr std::string_view kTextOnly = "Hello World";
+constexpr std::string_view kUnclosedTag = "<div>content";
+constexpr std::string_view kEmptyTagName = "<>content</>";
+constexpr std::string_view kIncompleteTag = "<div";
+constexpr std::string_view kPositionTest = "<p>test</p>";
+constexpr std::string_view kWhitespaceTest = "<  div  >  content  </  div  >";
+
+}  // anonymous namespace
+
+// Helper struct to reduce boilerplate code
+struct TokenCollectors {
+  std::vector<HtmlToken> open_tokens;
+  std::vector<HtmlTextToken> text_tokens;
+  std::vector<HtmlCloseToken> close_tokens;
+};
+
+class HtmlTagProviderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+
+  // helper function: set callback for collecting tokens
+  void SetupTokenCollectors(HtmlTagProvider& provider, std::vector<HtmlToken>& open_tokens,
+                            std::vector<HtmlTextToken>& text_tokens, std::vector<HtmlCloseToken>& close_tokens) {
+    provider.set_feed_open_token_callback([&open_tokens](HtmlToken&& token) {
+      open_tokens.push_back(std::move(token));
+      return true;
+    });
+
+    provider.set_feed_text_token_callback([&text_tokens](HtmlTextToken&& token) {
+      text_tokens.push_back(std::move(token));
+      return true;
+    });
+
+    provider.set_feed_close_token_callback([&close_tokens](HtmlCloseToken&& token) {
+      close_tokens.push_back(std::move(token));
+      return true;
+    });
+  }
+
+  // overloaded helper function using TokenCollectors struct
+  void SetupTokenCollectors(HtmlTagProvider& provider, TokenCollectors& collectors) {
+    SetupTokenCollectors(provider, collectors.open_tokens, collectors.text_tokens, collectors.close_tokens);
+  }
+};
+
+/**
+ * 1. Test basic Parse() behavior
+ */
+TEST_F(HtmlTagProviderTest, ParseEmptyString) {
+  HtmlTagProvider provider(kEmptyString);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_TRUE(tokens.open_tokens.empty());
+  EXPECT_TRUE(tokens.text_tokens.empty());
+  EXPECT_TRUE(tokens.close_tokens.empty());
+}
+
+TEST_F(HtmlTagProviderTest, ParseTextOnly) {
+  HtmlTagProvider provider(kTextOnly);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  // TODO(Team): Discuss with team about returning false for text-only content
+  // Text-only content always causes Parse() to return false
+  // because FindNextChar returns npos when '<' is not found
+  EXPECT_FALSE(provider.Parse());
+
+  // Even though parsing fails, text token should still be created
+  EXPECT_TRUE(tokens.open_tokens.empty());
+  EXPECT_EQ(tokens.text_tokens.size(), 1);
+  EXPECT_TRUE(tokens.close_tokens.empty());
+
+  EXPECT_EQ(tokens.text_tokens[0].text_content, "Hello World");
+  EXPECT_EQ(tokens.text_tokens[0].begin_pos, 0);
+}
+
+TEST_F(HtmlTagProviderTest, ParseSimpleTag) {
+  HtmlTagProvider provider(kSimpleTag);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_EQ(tokens.open_tokens.size(), 1);
+  EXPECT_TRUE(tokens.text_tokens.empty());
+  EXPECT_EQ(tokens.close_tokens.size(), 1);
+
+  // Open tag validation
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kDiv);
+  EXPECT_FALSE(tokens.open_tokens[0].is_void_tag);
+  EXPECT_EQ(tokens.open_tokens[0].begin_pos, 0);
+  EXPECT_EQ(tokens.open_tokens[0].end_pos, 5);
+
+  // Close tag validation
+  EXPECT_EQ(tokens.close_tokens[0].tag, Tag::kDiv);
+  EXPECT_EQ(tokens.close_tokens[0].begin_pos, 5);
+  EXPECT_EQ(tokens.close_tokens[0].end_pos, 11);
+}
+
+TEST_F(HtmlTagProviderTest, ParseTagWithText) {
+  HtmlTagProvider provider(kTagWithText);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_EQ(tokens.open_tokens.size(), 1);
+  EXPECT_EQ(tokens.text_tokens.size(), 1);
+  EXPECT_EQ(tokens.close_tokens.size(), 1);
+
+  // Open tag validation
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kP);
+  EXPECT_FALSE(tokens.open_tokens[0].is_void_tag);
+
+  // Text validation
+  EXPECT_EQ(tokens.text_tokens[0].text_content, "Hello World");
+
+  // Close tag validation
+  EXPECT_EQ(tokens.close_tokens[0].tag, Tag::kP);
+}
+
+TEST_F(HtmlTagProviderTest, ParseNestedTags) {
+  HtmlTagProvider provider(kNestedTags);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_EQ(tokens.open_tokens.size(), 2);
+  EXPECT_EQ(tokens.text_tokens.size(), 1);
+  EXPECT_EQ(tokens.close_tokens.size(), 2);
+
+  // first open tag (div)
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kDiv);
+
+  // second open tag (span)
+  EXPECT_EQ(tokens.open_tokens[1].tag, Tag::kSpan);
+
+  // Text
+  EXPECT_EQ(tokens.text_tokens[0].text_content, "nested");
+
+  // Close tags (span, div order)
+  EXPECT_EQ(tokens.close_tokens[0].tag, Tag::kSpan);
+  EXPECT_EQ(tokens.close_tokens[1].tag, Tag::kDiv);
+}
+
+TEST_F(HtmlTagProviderTest, ParseVoidTag) {
+  HtmlTagProvider provider(kVoidTag);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_EQ(tokens.open_tokens.size(), 1);
+  EXPECT_TRUE(tokens.text_tokens.empty());
+  EXPECT_TRUE(tokens.close_tokens.empty());
+
+  // Void tag validation
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kBr);
+  EXPECT_TRUE(tokens.open_tokens[0].is_void_tag);
+}
+
+TEST_F(HtmlTagProviderTest, ParseMultipleVoidTags) {
+  HtmlTagProvider provider(kMultipleVoidTags);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_EQ(tokens.open_tokens.size(), 3);
+  EXPECT_TRUE(tokens.text_tokens.empty());
+  EXPECT_TRUE(tokens.close_tokens.empty());
+
+  // Each void tag validation
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kBr);
+  EXPECT_TRUE(tokens.open_tokens[0].is_void_tag);
+
+  EXPECT_EQ(tokens.open_tokens[1].tag, Tag::kImg);
+  EXPECT_TRUE(tokens.open_tokens[1].is_void_tag);
+
+  EXPECT_EQ(tokens.open_tokens[2].tag, Tag::kInput);
+  EXPECT_TRUE(tokens.open_tokens[2].is_void_tag);
+}
+
+TEST_F(HtmlTagProviderTest, ParseTagWithAttributes) {
+  HtmlTagProvider provider(kTagWithAttributes);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+  EXPECT_EQ(tokens.open_tokens.size(), 1);
+  EXPECT_EQ(tokens.text_tokens.size(), 1);
+  EXPECT_EQ(tokens.close_tokens.size(), 1);
+
+  // Even if attributes are present, the tag name should be parsed correctly
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kDiv);
+  EXPECT_EQ(tokens.text_tokens[0].text_content, "content");
+  EXPECT_EQ(tokens.close_tokens[0].tag, Tag::kDiv);
+
+  // TODO(Team): Add comprehensive attribute parsing tests
+  // - Test attribute extraction and validation
+  // - Test multiple attributes with different formats
+  // - Test attribute values with quotes (single/double)
+  // - Test malformed attributes handling
+}
+
+TEST_F(HtmlTagProviderTest, ParseComplexHtml) {
+  HtmlTagProvider provider(kComplexHtml);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+
+  // Expected tags: html, head, title, body, div
+  EXPECT_EQ(tokens.open_tokens.size(), 5);
+  EXPECT_EQ(tokens.close_tokens.size(), 5);
+
+  // Expected text: "Test", "Hello"
+  EXPECT_EQ(tokens.text_tokens.size(), 2);
+
+  // Tag order validation
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kHtml);
+  EXPECT_EQ(tokens.open_tokens[1].tag, Tag::kHead);
+  EXPECT_EQ(tokens.open_tokens[2].tag, Tag::kTitle);
+  EXPECT_EQ(tokens.open_tokens[3].tag, Tag::kBody);
+  EXPECT_EQ(tokens.open_tokens[4].tag, Tag::kDiv);
+
+  // Text content validation
+  EXPECT_EQ(tokens.text_tokens[0].text_content, "Test");
+  EXPECT_EQ(tokens.text_tokens[1].text_content, "Hello");
+
+  // Close tag order validation (should be reverse of open tags)
+  EXPECT_EQ(tokens.close_tokens[0].tag, Tag::kTitle);
+  EXPECT_EQ(tokens.close_tokens[1].tag, Tag::kHead);
+  EXPECT_EQ(tokens.close_tokens[2].tag, Tag::kDiv);
+  EXPECT_EQ(tokens.close_tokens[3].tag, Tag::kBody);
+  EXPECT_EQ(tokens.close_tokens[4].tag, Tag::kHtml);
+
+  // Position validation for key elements
+  // <html> tag positions
+  EXPECT_EQ(tokens.open_tokens[0].begin_pos, 0);
+  EXPECT_EQ(tokens.open_tokens[0].end_pos, 6);
+
+  // <title> tag positions
+  EXPECT_EQ(tokens.open_tokens[2].begin_pos, 12);
+  EXPECT_EQ(tokens.open_tokens[2].end_pos, 19);
+
+  // First text token "Test" positions
+  EXPECT_EQ(tokens.text_tokens[0].begin_pos, 19);
+  EXPECT_EQ(tokens.text_tokens[0].end_pos, 23);
+
+  // </title> close tag positions
+  EXPECT_EQ(tokens.close_tokens[0].begin_pos, 23);
+  EXPECT_EQ(tokens.close_tokens[0].end_pos, 31);
+}
+
+// Test error cases
+TEST_F(HtmlTagProviderTest, ParseMalformedTagUnclosedTag) {
+  HtmlTagProvider provider(kUnclosedTag);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  // Unclosed tag with trailing text always causes Parse() to return false
+  // because FindNextChar returns npos when no more '<' is found after the text
+  EXPECT_FALSE(provider.Parse());
+
+  // Even though parsing fails, tokens should still be created
+  EXPECT_EQ(tokens.open_tokens.size(), 1);   // <div> tag parsed
+  EXPECT_EQ(tokens.text_tokens.size(), 1);   // "content" text parsed
+  EXPECT_TRUE(tokens.close_tokens.empty());  // no closing tag
+}
+
+TEST_F(HtmlTagProviderTest, ParseMalformedTagEmptyTag) {
+  HtmlTagProvider provider(kEmptyTagName);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  // Empty tag name always causes Parse() to return false
+  // because extractTagName returns empty string, causing parseOpenTag to return npos
+  EXPECT_FALSE(provider.Parse());
+}
+
+TEST_F(HtmlTagProviderTest, ParseMalformedTagIncompleteTag) {
+  HtmlTagProvider provider(kIncompleteTag);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  // Incomplete tag (missing '>') always causes Parse() to return false
+  // because skipToTagEnd cannot find '>', causing parseOpenTag to return npos
+  EXPECT_FALSE(provider.Parse());
+
+  // No tokens should be created since tag parsing fails early
+  EXPECT_TRUE(tokens.open_tokens.empty());
+  EXPECT_TRUE(tokens.text_tokens.empty());
+  EXPECT_TRUE(tokens.close_tokens.empty());
+}
+
+// Test callback return value
+TEST_F(HtmlTagProviderTest, ParseCallbackReturnsFalseOpenToken) {
+  HtmlTagProvider provider(kSimpleTag);
+
+  std::vector<HtmlToken> open_tokens;
+  std::vector<HtmlTextToken> text_tokens;
+  std::vector<HtmlCloseToken> close_tokens;
+
+  // Set callback to return false for open token
+  provider.set_feed_open_token_callback([&open_tokens](HtmlToken&& token) {
+    open_tokens.push_back(std::move(token));
+    return false;  // parsing stop
+  });
+
+  provider.set_feed_text_token_callback([&text_tokens](HtmlTextToken&& token) {
+    text_tokens.push_back(std::move(token));
+    return true;
+  });
+
+  provider.set_feed_close_token_callback([&close_tokens](HtmlCloseToken&& token) {
+    close_tokens.push_back(std::move(token));
+    return true;
+  });
+
+  EXPECT_FALSE(provider.Parse());    // false return due to parsing failure
+  EXPECT_EQ(open_tokens.size(), 1);  // first token is processed
+  EXPECT_TRUE(text_tokens.empty());  // subsequent tokens are not processed
+  EXPECT_TRUE(close_tokens.empty());
+}
+
+TEST_F(HtmlTagProviderTest, ParseCallbackReturnsFalseTextToken) {
+  HtmlTagProvider provider(kTagWithText);
+
+  std::vector<HtmlToken> open_tokens;
+  std::vector<HtmlTextToken> text_tokens;
+  std::vector<HtmlCloseToken> close_tokens;
+
+  provider.set_feed_open_token_callback([&open_tokens](HtmlToken&& token) {
+    open_tokens.push_back(std::move(token));
+    return true;
+  });
+
+  // Set callback to return false for text token
+  provider.set_feed_text_token_callback([&text_tokens](HtmlTextToken&& token) {
+    text_tokens.push_back(std::move(token));
+    return false;  // parsing stop
+  });
+
+  provider.set_feed_close_token_callback([&close_tokens](HtmlCloseToken&& token) {
+    close_tokens.push_back(std::move(token));
+    return true;
+  });
+
+  EXPECT_FALSE(provider.Parse());     // false return due to parsing failure
+  EXPECT_EQ(open_tokens.size(), 1);   // Open tag is processed
+  EXPECT_EQ(text_tokens.size(), 1);   // Text token is processed
+  EXPECT_TRUE(close_tokens.empty());  // Close tag is not processed
+}
+
+TEST_F(HtmlTagProviderTest, ParseCallbackReturnsFalseCloseToken) {
+  HtmlTagProvider provider(kSimpleTag);
+
+  std::vector<HtmlToken> open_tokens;
+  std::vector<HtmlTextToken> text_tokens;
+  std::vector<HtmlCloseToken> close_tokens;
+
+  provider.set_feed_open_token_callback([&open_tokens](HtmlToken&& token) {
+    open_tokens.push_back(std::move(token));
+    return true;
+  });
+
+  provider.set_feed_text_token_callback([&text_tokens](HtmlTextToken&& token) {
+    text_tokens.push_back(std::move(token));
+    return true;
+  });
+
+  // Set callback to return false for close token
+  provider.set_feed_close_token_callback([&close_tokens](HtmlCloseToken&& token) {
+    close_tokens.push_back(std::move(token));
+    return false;  // parsing stop
+  });
+
+  EXPECT_FALSE(provider.Parse());     // false return due to parsing failure
+  EXPECT_EQ(open_tokens.size(), 1);   // Open tag is processed
+  EXPECT_TRUE(text_tokens.empty());   // Text is empty
+  EXPECT_EQ(close_tokens.size(), 1);  // Close tag is processed
+}
+
+// Test parsing without callbacks
+TEST_F(HtmlTagProviderTest, ParseNoCallbacks) {
+  HtmlTagProvider provider(kComplexHtml);
+
+  // Parse without callbacks
+  EXPECT_TRUE(provider.Parse());  // Parse should succeed even without callbacks
+}
+
+// Test position information accuracy
+TEST_F(HtmlTagProviderTest, ParsePositionAccuracy) {
+  HtmlTagProvider provider(kPositionTest);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  EXPECT_TRUE(provider.Parse());
+
+  // Position accuracy validation
+  EXPECT_EQ(tokens.open_tokens[0].begin_pos, 0);  // <p>
+  EXPECT_EQ(tokens.open_tokens[0].end_pos, 3);
+
+  EXPECT_EQ(tokens.text_tokens[0].begin_pos, 3);  // test
+  EXPECT_EQ(tokens.text_tokens[0].end_pos, 7);
+
+  EXPECT_EQ(tokens.close_tokens[0].begin_pos, 7);  // </p>
+  EXPECT_EQ(tokens.close_tokens[0].end_pos, 11);
+}
+
+// Test whitespace handling within tags and text
+TEST_F(HtmlTagProviderTest, ParseWhitespaceHandling) {
+  HtmlTagProvider provider(kWhitespaceTest);
+  TokenCollectors tokens;
+
+  SetupTokenCollectors(provider, tokens);
+
+  // Whitespace within tags should be handled correctly and parsing should succeed
+  EXPECT_TRUE(provider.Parse());
+
+  // All tokens should be created correctly despite whitespace
+  EXPECT_EQ(tokens.open_tokens.size(), 1);
+  EXPECT_EQ(tokens.open_tokens[0].tag, Tag::kDiv);
+
+  EXPECT_EQ(tokens.text_tokens.size(), 1);
+  EXPECT_EQ(tokens.close_tokens.size(), 1);
+  EXPECT_EQ(tokens.close_tokens[0].tag, Tag::kDiv);
+
+  // Text content should preserve whitespace
+  EXPECT_EQ(tokens.text_tokens[0].text_content, "  content  ");
+}
+
+}  // namespace arboris

--- a/tests/string_test.cc
+++ b/tests/string_test.cc
@@ -1,0 +1,298 @@
+/*
+ *   Copyright 2025 Team Arboris
+ *   Licensed under the Apache License, Version 2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <string_view>
+
+#include "string/string.hpp"
+
+namespace arboris {
+namespace {
+
+// Test data constants
+constexpr std::string_view kEmptyString = "";
+constexpr std::string_view kWhitespaceString = "   \t\n\r  ";
+constexpr std::string_view kMixedString = "hello world\ttest\n";
+constexpr std::string_view kNoWhitespaceString = "helloworld";
+constexpr std::string_view kSpecialChars = "!@#$%^&*()";
+
+// Additional test data for inline strings
+constexpr std::string_view kHelloString = "hello";
+constexpr std::string_view kWorldString = "world";
+constexpr std::string_view kHelloWorldString = "hello world";
+constexpr std::string_view kSpacedHelloString = "   hello";
+constexpr std::string_view kTabNewlineHelloString = "\t\n hello";
+constexpr std::string_view kMixedWhitespaceHelloString = " \r\n\t hello";
+
+}  // anonymous namespace
+
+class StringUtilsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+// SkipWhitespace tests
+TEST_F(StringUtilsTest, SkipWhitespaceEmptyString) {
+  EXPECT_EQ(SkipWhitespace(kEmptyString, 0), 0);
+}
+
+TEST_F(StringUtilsTest, SkipWhitespaceNoWhitespace) {
+  EXPECT_EQ(SkipWhitespace(kNoWhitespaceString, 0), 0);
+  EXPECT_EQ(SkipWhitespace(kHelloString, 2), 2);  // Start from middle
+}
+
+TEST_F(StringUtilsTest, SkipWhitespaceWithWhitespace) {
+  EXPECT_EQ(SkipWhitespace(kSpacedHelloString, 0), 3);
+  EXPECT_EQ(SkipWhitespace(kTabNewlineHelloString, 0), 3);
+  EXPECT_EQ(SkipWhitespace(kMixedWhitespaceHelloString, 0), 5);
+}
+
+TEST_F(StringUtilsTest, SkipWhitespaceAllWhitespace) {
+  EXPECT_EQ(SkipWhitespace(kWhitespaceString, 0), kWhitespaceString.length());
+}
+
+TEST_F(StringUtilsTest, SkipWhitespaceBoundaryConditions) {
+  // Start from end of string
+  EXPECT_EQ(SkipWhitespace(kHelloWorldString, kHelloWorldString.length()), kHelloWorldString.length());
+
+  // Position beyond string length
+  EXPECT_EQ(SkipWhitespace(kHelloWorldString, kHelloWorldString.length() + 1), kHelloWorldString.length() + 1);
+
+  // Maximum size_t value (overflow test)
+  EXPECT_EQ(SkipWhitespace(kHelloWorldString, std::numeric_limits<std::size_t>::max()),
+            std::numeric_limits<std::size_t>::max());
+}
+
+// ExtractSubstring tests
+TEST_F(StringUtilsTest, ExtractSubstringNormalCases) {
+  EXPECT_EQ(ExtractSubstring(kHelloWorldString, 0, 5), kHelloString);
+  EXPECT_EQ(ExtractSubstring(kHelloWorldString, 6, 11), kWorldString);
+  EXPECT_EQ(ExtractSubstring(kHelloWorldString, 0, kHelloWorldString.length()), kHelloWorldString);
+}
+
+TEST_F(StringUtilsTest, ExtractSubstringEmptyResults) {
+  // start == end
+  EXPECT_EQ(ExtractSubstring(kHelloString, 2, 2), kEmptyString);
+
+  // start > end
+  EXPECT_EQ(ExtractSubstring(kHelloString, 3, 2), kEmptyString);
+
+  // start >= length
+  EXPECT_EQ(ExtractSubstring(kHelloString, 5, 10), kEmptyString);
+  EXPECT_EQ(ExtractSubstring(kHelloString, 10, 15), kEmptyString);
+}
+
+TEST_F(StringUtilsTest, ExtractSubstringEmptyString) {
+  EXPECT_EQ(ExtractSubstring(kEmptyString, 0, 0), "");
+  EXPECT_EQ(ExtractSubstring(kEmptyString, 0, 5), "");
+  EXPECT_EQ(ExtractSubstring(kEmptyString, 5, 10), "");
+}
+
+TEST_F(StringUtilsTest, ExtractSubstringEndBeyondLength) {
+  std::string_view test_str = "hello";
+
+  // When end > length, return up to the entire string
+  EXPECT_EQ(ExtractSubstring(test_str, 0, 10), "hello");
+  EXPECT_EQ(ExtractSubstring(test_str, 2, 10), "llo");
+}
+
+TEST_F(StringUtilsTest, ExtractSubstringBoundaryConditions) {
+  std::string_view test_str = "test";
+
+  // Maximum size_t values
+  EXPECT_EQ(
+      ExtractSubstring(test_str, std::numeric_limits<std::size_t>::max(), std::numeric_limits<std::size_t>::max()), "");
+
+  // Large end value
+  EXPECT_EQ(ExtractSubstring(test_str, 0, std::numeric_limits<std::size_t>::max()), "test");
+}
+
+// FindNextChar tests
+TEST_F(StringUtilsTest, FindNextCharFound) {
+  std::string_view test_str = "hello world";
+
+  EXPECT_EQ(FindNextChar(test_str, 0, 'h'), 0);
+  EXPECT_EQ(FindNextChar(test_str, 0, 'e'), 1);
+  EXPECT_EQ(FindNextChar(test_str, 0, 'l'), 2);  // First 'l'
+  EXPECT_EQ(FindNextChar(test_str, 3, 'l'), 3);  // Second 'l'
+  EXPECT_EQ(FindNextChar(test_str, 0, ' '), 5);
+}
+
+TEST_F(StringUtilsTest, FindNextCharNotFound) {
+  std::string_view test_str = "hello world";
+
+  EXPECT_EQ(FindNextChar(test_str, 0, 'x'), std::string::npos);
+  EXPECT_EQ(FindNextChar(test_str, 0, 'z'), std::string::npos);
+
+  // Character not found after start position
+  EXPECT_EQ(FindNextChar(test_str, 6, 'h'), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextCharEmptyString) {
+  EXPECT_EQ(FindNextChar(kEmptyString, 0, 'a'), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextCharBoundaryConditions) {
+  std::string_view test_str = "hello";
+
+  // Start from end of string
+  EXPECT_EQ(FindNextChar(test_str, test_str.length(), 'h'), std::string::npos);
+
+  // Position beyond string length
+  EXPECT_EQ(FindNextChar(test_str, test_str.length() + 1, 'h'), std::string::npos);
+
+  // Maximum size_t value
+  EXPECT_EQ(FindNextChar(test_str, std::numeric_limits<std::size_t>::max(), 'h'), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextCharSpecialCharacters) {
+  std::string_view test_str = "hello\tworld\n";
+
+  EXPECT_EQ(FindNextChar(test_str, 0, '\t'), 5);
+  EXPECT_EQ(FindNextChar(test_str, 0, '\n'), 11);
+  EXPECT_EQ(FindNextChar(test_str, 0, '\0'), std::string::npos);
+}
+
+// FindNextAnyChar tests
+TEST_F(StringUtilsTest, FindNextAnyCharFound) {
+  std::string_view test_str = "hello world";
+
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, "aeiou"), 1);  // 'e'
+  EXPECT_EQ(FindNextAnyChar(test_str, 2, "aeiou"), 4);  // 'o'
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, "hw"), 0);     // 'h'
+  EXPECT_EQ(FindNextAnyChar(test_str, 1, "hw"), 6);     // 'w'
+}
+
+TEST_F(StringUtilsTest, FindNextAnyCharNotFound) {
+  std::string_view test_str = "hello world";
+
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, "xyz"), std::string::npos);
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, "123"), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextAnyCharEmptyTargets) {
+  std::string_view test_str = "hello";
+
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, ""), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextAnyCharEmptyString) {
+  EXPECT_EQ(FindNextAnyChar(kEmptyString, 0, "abc"), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextAnyCharBoundaryConditions) {
+  std::string_view test_str = "hello";
+
+  // Start from end of string
+  EXPECT_EQ(FindNextAnyChar(test_str, test_str.length(), "helo"), std::string::npos);
+
+  // Position beyond string length
+  EXPECT_EQ(FindNextAnyChar(test_str, test_str.length() + 1, "helo"), std::string::npos);
+
+  // Maximum size_t value
+  EXPECT_EQ(FindNextAnyChar(test_str, std::numeric_limits<std::size_t>::max(), "helo"), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, FindNextAnyCharSingleChar) {
+  std::string_view test_str = "hello";
+
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, "h"), 0);
+  EXPECT_EQ(FindNextAnyChar(test_str, 0, "e"), 1);
+}
+
+// SkipUntilChar tests
+TEST_F(StringUtilsTest, SkipUntilCharFound) {
+  std::string_view test_str = "hello world";
+
+  EXPECT_EQ(SkipUntilChar(test_str, 0, ' '), 5);
+  EXPECT_EQ(SkipUntilChar(test_str, 0, 'w'), 6);
+  EXPECT_EQ(SkipUntilChar(test_str, 0, 'h'), 0);  // First character
+}
+
+TEST_F(StringUtilsTest, SkipUntilCharNotFound) {
+  std::string_view test_str = "hello world";
+
+  EXPECT_EQ(SkipUntilChar(test_str, 0, 'x'), std::string::npos);
+  EXPECT_EQ(SkipUntilChar(test_str, 0, 'z'), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, SkipUntilCharEmptyString) {
+  EXPECT_EQ(SkipUntilChar(kEmptyString, 0, 'a'), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, SkipUntilCharBoundaryConditions) {
+  std::string_view test_str = "hello";
+
+  // Start from end of string
+  EXPECT_EQ(SkipUntilChar(test_str, test_str.length(), 'h'), std::string::npos);
+
+  // Position beyond string length
+  EXPECT_EQ(SkipUntilChar(test_str, test_str.length() + 1, 'h'), std::string::npos);
+
+  // Maximum size_t value
+  EXPECT_EQ(SkipUntilChar(test_str, std::numeric_limits<std::size_t>::max(), 'h'), std::string::npos);
+}
+
+TEST_F(StringUtilsTest, SkipUntilCharConsistencyWithFindNextChar) {
+  std::string_view test_str = "hello world test";
+
+  // SkipUntilChar should return the same result as FindNextChar
+  EXPECT_EQ(SkipUntilChar(test_str, 0, ' '), FindNextChar(test_str, 0, ' '));
+  EXPECT_EQ(SkipUntilChar(test_str, 5, 't'), FindNextChar(test_str, 5, 't'));
+  EXPECT_EQ(SkipUntilChar(test_str, 0, 'x'), FindNextChar(test_str, 0, 'x'));
+}
+
+// Integration safety tests
+TEST_F(StringUtilsTest, IntegrationSafetyChainedOperations) {
+  std::string_view test_str = "  hello world  ";
+
+  // Verify that chained operations work safely
+  std::size_t start = SkipWhitespace(test_str, 0);
+  EXPECT_EQ(start, 2);
+
+  std::size_t space_pos = FindNextChar(test_str, start, ' ');
+  EXPECT_EQ(space_pos, 7);
+
+  std::string_view word = ExtractSubstring(test_str, start, space_pos);
+  EXPECT_EQ(word, "hello");
+
+  std::size_t next_start = SkipWhitespace(test_str, space_pos);
+  EXPECT_EQ(next_start, 8);
+}
+
+TEST_F(StringUtilsTest, IntegrationSafetyEdgeCaseChaining) {
+  std::string_view empty_str = "";
+
+  // Chained operations on empty string
+  std::size_t pos1 = SkipWhitespace(empty_str, 0);
+  std::size_t pos2 = FindNextChar(empty_str, pos1, 'a');
+  std::string_view result = ExtractSubstring(empty_str, pos1, pos2);
+
+  EXPECT_EQ(pos1, 0);
+  EXPECT_EQ(pos2, std::string::npos);
+  EXPECT_EQ(result, "");
+}
+
+// Memory safety test (prevent dangling pointers)
+TEST_F(StringUtilsTest, MemorySafetyStringViewLifetime) {
+  std::string_view result;
+
+  {
+    std::string temp_str = "temporary string";
+    std::string_view temp_view = temp_str;
+    result = ExtractSubstring(temp_view, 0, 9);
+    // Use result before temp_str goes out of scope
+    EXPECT_EQ(result, "temporary");
+  }
+
+  // Using result here could create a dangling pointer
+  // This is something users need to be careful about, so we don't test it
+}
+
+}  // namespace arboris


### PR DESCRIPTION
# 🧪 HTML 태그 파싱 및 문자열 유틸리티 함수 단위 테스트 추가

## 📋 개요

HTML 태그 파서와 문자열 유틸리티 함수들의 안정성과 정확성을 보장하기 위한 포괄적인 단위 테스트를 추가했습니다.

## 🔧 주요 변경사항

### ✅ 새로운 테스트 파일 추가

- **`tests/html_tag_provider_test.cc`** (475줄): HTML 태그 파싱 기능 테스트
- **`tests/string_test.cc`** (298줄): 문자열 유틸리티 함수 테스트
- **`tests/CMakeLists.txt`** 업데이트: 새로운 테스트 파일들을 빌드 시스템에 포함

### 🏷️ HTML 태그 파싱 테스트 커버리지

- **기본 태그 파싱**: 단순 태그, 중첩 태그, void 태그
- **속성 처리**: 클래스, ID 등 다양한 HTML 속성
- **복잡한 HTML 구조**: 완전한 HTML 문서 파싱
- **에러 처리**: 잘못된 형식의 태그, 닫히지 않은 태그, 불완전한 태그
- **엣지 케이스**: 빈 문자열, 텍스트만 있는 경우, 공백 처리

### 🔤 문자열 유틸리티 테스트 커버리지

- **`SkipWhitespace`**: 공백 문자 건너뛰기 기능
- **`ExtractSubstring`**: 부분 문자열 추출 기능
- **`FindNextChar`**: 다음 문자 찾기 기능
- **경계값 테스트**: 빈 문자열, 인덱스 범위 초과 등

## 🎯 테스트 품질

- **포괄적인 커버리지**: 정상 케이스부터 에러 케이스까지
- **명확한 테스트 구조**: 각 기능별로 체계적으로 분류
- **실용적인 테스트 데이터**: 실제 사용 시나리오를 반영한 테스트 케이스

## 📊 통계

- **총 추가된 코드**: 779줄
- **테스트 파일**: 2개 신규 추가
- **테스트 케이스**: 다양한 시나리오를 커버하는 포괄적인 테스트 스위트

## 🔍 테스트 실행

```bash
# 테스트 실행
cmake --build build --target html_tag_provider_test string_test
./build/tests/html_tag_provider_test
./build/tests/string_test
```