### PR TITLE
jayden/basic-query-implement

### DIFF
--- a/src/dom/dom_builder.cc
+++ b/src/dom/dom_builder.cc
@@ -20,11 +20,11 @@ bool DOMBuilder::Validate() const {
 
 bool DOMBuilder::FeedOpenToken(HtmlToken&& token, const char* text_begin) {
   bool is_void_tag = token.is_void_tag;
-  auto parent = node_stack_.empty() ? root_ : node_stack_.top();
+  auto parent = node_stack_.empty() ? root() : node_stack_.top();
   auto node = std::make_shared<TagNode>(
     next_node_id_++,
     std::move(token),
-    parent);
+    parent.get());
 
   node->set_in(++euler_tour_timer_);
   node_stack_.push(node);
@@ -46,7 +46,7 @@ bool DOMBuilder::FeedOpenToken(HtmlToken&& token, const char* text_begin) {
 }
 
 bool DOMBuilder::FeedTextToken(HtmlTextToken&& token) {
-  auto parent = node_stack_.empty() ? root_ : node_stack_.top();
+  auto parent = node_stack_.empty() ? root() : node_stack_.top();
 
   auto text_node = std::make_shared<TextNode>(
     next_node_id_++,

--- a/src/dom/dom_builder.hpp
+++ b/src/dom/dom_builder.hpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <utility>
 #include <cstdint>
+#include <vector>
 
 #include "utils/html_tokens.hpp"
 #include "dom/tag_node.hpp"
@@ -23,7 +24,7 @@ class DOMBuilder {
   using NodeCreationCallback = std::function<void(const std::shared_ptr<TagNode>&)>;
 
  public:
-  DOMBuilder() : root_(std::make_shared<TagNode>(0, HtmlToken{{0, 0}, Tag::kHtml, false}, nullptr)) {}
+  DOMBuilder(): dfs_node_list_{std::make_shared<TagNode>(0, HtmlToken{{0, 0}, Tag::kHtml, false}, nullptr)} {}
   DOMBuilder(const DOMBuilder&) = delete;
   DOMBuilder& operator=(const DOMBuilder&) = delete;
   DOMBuilder(DOMBuilder&&) = delete;
@@ -39,14 +40,23 @@ class DOMBuilder {
     node_creation_callback_ = std::move(callback);
   }
 
+  [[nodiscard]] const std::vector<std::shared_ptr<TagNode>>& GetNodeList() const {
+    return dfs_node_list_;
+  }
+
  private:
+  [[nodiscard]] std::shared_ptr<TagNode> root() {
+    ARBORIS_ASSERT(!dfs_node_list_.empty(), "Root node is nullptr.");
+    return dfs_node_list_.front();
+  }
+
   bool closeTopNode();
 
  private:
   std::uint32_t next_node_id_{0};
   std::uint32_t euler_tour_timer_{0};
 
-  std::shared_ptr<TagNode> root_;
+  std::vector<std::shared_ptr<TagNode>> dfs_node_list_;
   std::stack<std::shared_ptr<TagNode>> node_stack_;
 
   NodeCreationCallback node_creation_callback_;

--- a/src/dom/dom_indexer.cc
+++ b/src/dom/dom_indexer.cc
@@ -37,4 +37,9 @@ std::optional<NodeList> DOMIndexer::GetNodesByClass(std::string_view class_name)
   return it != class_index_.end() ? std::make_optional(it->second) : std::nullopt;
 }
 
+std::optional<NodeList> DOMIndexer::GetNodesByAttribute(std::string_view attribute_name) const {
+  auto it = attr_index_.find(std::string(attribute_name));
+  return it != attr_index_.end() ? std::make_optional(it->second) : std::nullopt;
+}
+
 }  // namespace arboris

--- a/src/dom/dom_indexer.hpp
+++ b/src/dom/dom_indexer.hpp
@@ -30,12 +30,15 @@ class DOMIndexer {
   [[nodiscard]] NodePtr GetNodeById(std::string_view id) const;
   [[nodiscard]] std::optional<NodeList> GetNodesByTag(Tag tag) const;
   [[nodiscard]] std::optional<NodeList> GetNodesByClass(std::string_view class_name) const;
+  [[nodiscard]] std::optional<NodeList> GetNodesByAttribute(std::string_view attribute_name) const;
 
  private:
   // TODO(team): consider using std::list instead of std::vector for indexes
   std::unordered_map<std::string, NodePtr> id_index_;
   std::unordered_map<Tag, NodeList> tag_index_;
   std::unordered_map<std::string, NodeList> class_index_;
+
+  // TODO(team): consider indexing by value instead of name
   std::unordered_map<std::string, NodeList> attr_index_;
 };
 

--- a/src/dom/dom_manager.cc
+++ b/src/dom/dom_manager.cc
@@ -12,29 +12,28 @@ namespace arboris {
 
 DOMManager::DOMManager(std::string_view html_content) :
   string_pool_(std::make_shared<StringPool>(html_content.size())),
-  dom_builder_(),
-  dom_indexer_(),
-  html_token_parser_(html_content, string_pool_) {
-  parse();
-}
+  dom_indexer_() {
+  DOMBuilder builder;
+  HtmlTokenParser html_token_parser(html_content, string_pool_);
 
-void DOMManager::parse() {
-  // Set up callbacks for HtmlTokenParser
-  html_token_parser_.set_feed_open_token_callback(
-      std::bind(&DOMBuilder::FeedOpenToken, &dom_builder_, std::placeholders::_1, std::placeholders::_2));
+  html_token_parser.set_feed_open_token_callback(
+      std::bind(&DOMBuilder::FeedOpenToken, &builder, std::placeholders::_1, std::placeholders::_2));
 
-  html_token_parser_.set_feed_text_token_callback(
-      std::bind(&DOMBuilder::FeedTextToken, &dom_builder_, std::placeholders::_1));
+  html_token_parser.set_feed_text_token_callback(
+      std::bind(&DOMBuilder::FeedTextToken, &builder, std::placeholders::_1));
 
-  html_token_parser_.set_feed_close_token_callback(
-      std::bind(&DOMBuilder::FeedCloseToken, &dom_builder_, std::placeholders::_1, std::placeholders::_2));
+  html_token_parser.set_feed_close_token_callback(
+      std::bind(&DOMBuilder::FeedCloseToken, &builder, std::placeholders::_1, std::placeholders::_2));
 
   // Set up node creation callback for DOMBuilder to index nodes
-  dom_builder_.SetNodeCreationCallback(
+  builder.SetNodeCreationCallback(
       std::bind(&DOMIndexer::AddNode, &dom_indexer_, std::placeholders::_1));
 
-  // Start parsing
-  html_token_parser_.Parse();
+  html_token_parser.Parse();
+
+  ARBORIS_ASSERT(builder.Validate(), "DOM structure is invalid after parsing.");
 }
+
+
 
 }  // namespace arboris

--- a/src/dom/dom_manager.hpp
+++ b/src/dom/dom_manager.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "dom/dom_builder.hpp"
 #include "dom/dom_indexer.hpp"
@@ -28,19 +29,16 @@ class DOMManager {
   DOMManager& operator=(DOMManager&&) = delete;
   virtual ~DOMManager() = default;
 
-  bool IsValid() const {
-    ARBORIS_ASSERT(dom_builder_, "DOMBuilder is null");
-    return dom_builder_.Validate();
+  [[nodiscard]] const TagNode& GetRoot() const {
+    ARBORIS_ASSERT(!dfs_node_list_.empty(), "Root node is nullptr.");
+    return dfs_node_list_.front();
   }
 
  private:
-  void parse();
-
-  // string pool must be initialized before parser and builder
+  // Nodes list ordered by DFS in-order
+  std::vector<TagNode> dfs_node_list_;
   std::shared_ptr<StringPool> string_pool_;
-  DOMBuilder dom_builder_;
   DOMIndexer dom_indexer_;
-  HtmlTokenParser html_token_parser_;
 };
 
 }  // namespace arboris

--- a/src/dom/dom_query.cc
+++ b/src/dom/dom_query.cc
@@ -8,13 +8,28 @@
 
 #include <optional>
 #include <string>
+#include <limits>
 #include <vector>
+#include <utility>
+
+#include "utils/set_utils.hpp"
 
 namespace arboris {
 
 std::optional<DOMQuery> DOMQuery::Find(const QueryOptions& options) const {
   // TODO(team): Implement this
-  return DOMQuery(root_, dom_indexer_);
+  auto candidates = searchCandidatesFromIndexer(options);
+  if (candidates.empty()) {
+    return std::nullopt;
+  }
+
+  for (const auto& candidate : candidates) {
+    if (matchAllConditions(candidate, options)) {
+      return DOMQuery(*candidate, dom_indexer_);
+    }
+  }
+
+  return std::nullopt;
 }
 
 std::optional<DOMQuery> DOMQuery::Find(const std::string& id) const {
@@ -29,9 +44,86 @@ std::optional<DOMQuery> DOMQuery::Find(const std::string& id) const {
 std::vector<DOMQuery> DOMQuery::FindAll(const QueryOptions& options) const {
   std::vector<DOMQuery> ret;
 
-  const auto& tag_filtered_list = dom_indexer_.get().GetNodesByTag(options.tag.value());
-
+  auto candidates = searchCandidatesFromIndexer(options);
+  for (const auto& candidate : candidates) {
+    if (matchAllConditions(candidate, options)) {
+      ret.push_back(DOMQuery(*candidate, dom_indexer_));
+    }
+  }
   return ret;
+}
+
+NodeList DOMQuery::searchCandidatesFromIndexer(const QueryOptions& options) const {
+  std::size_t min_size = std::numeric_limits<std::size_t>::max();
+  NodeList min_candidates;
+
+  if (options.tag.has_value()) {
+    auto nodes = dom_indexer_.get().GetNodesByTag(options.tag.value());
+    if (nodes.has_value()) {
+      if (nodes->size() < min_size) {
+        min_size = nodes->size();
+        min_candidates = std::move(*nodes);
+      }
+    }
+  }
+
+  if (options.classes.has_value()) {
+    for (const auto& class_name : *options.classes) {
+      auto nodes = dom_indexer_.get().GetNodesByClass(class_name);
+      if (nodes.has_value()) {
+        if (nodes->size() < min_size) {
+          min_size = nodes->size();
+          min_candidates = std::move(*nodes);
+        }
+      }
+    }
+  }
+
+  if (options.attributes.has_value()) {
+    for (const auto& [attribute_name, _] : options.attributes.value()) {
+      auto nodes = dom_indexer_.get().GetNodesByAttribute(attribute_name);
+      if (nodes.has_value()) {
+        if (nodes->size() < min_size) {
+          min_size = nodes->size();
+          min_candidates = std::move(*nodes);
+        }
+      }
+    }
+  }
+
+  if (min_candidates.empty()) {
+    return {};
+  }
+
+  return min_candidates;
+}
+
+bool DOMQuery::matchAllConditions(const NodePtr& node, const QueryOptions& options) const {
+  if (!isSubNode(node)) {
+    return false;
+  }
+
+  if (options.tag && node->tag() != options.tag.value()) {
+    return false;
+  }
+
+  if (options.classes && !IsSubset(options.classes.value(), node->classes())) {
+    return false;
+  }
+
+  if (options.attributes && !IsSubset(options.attributes.value(), node->attributes())) {
+    return false;
+  }
+  // TODO(team): Implement text condition matching
+  return true;
+}
+
+bool DOMQuery::isSubNode(const NodePtr& node) const {
+  const uint32_t node_in = node->in();
+  const uint32_t node_out = node->out();
+  const uint32_t root_in = root_.get().in();
+  const uint32_t root_out = root_.get().out();
+  return node_in >= root_in && node_out <= root_out;
 }
 
 }  // namespace arboris

--- a/src/dom/dom_query.cc
+++ b/src/dom/dom_query.cc
@@ -18,7 +18,6 @@ std::optional<DOMQuery> DOMQuery::Find(const QueryOptions& options) const {
 }
 
 std::optional<DOMQuery> DOMQuery::Find(const std::string& id) const {
-  // TODO(team): Implement this
   NodePtr node = dom_indexer_.get().GetNodeById(id);
   if (node) {
     return DOMQuery(*node, dom_indexer_);

--- a/src/dom/dom_query.hpp
+++ b/src/dom/dom_query.hpp
@@ -39,8 +39,12 @@ class DOMQuery {
   std::vector<DOMQuery> FindAll(const QueryOptions& options) const;
 
  private:
-    std::reference_wrapper<const TagNode> root_;
-    std::reference_wrapper<const DOMIndexer> dom_indexer_;
+  NodeList searchCandidatesFromIndexer(const QueryOptions& options) const;
+  bool matchAllConditions(const NodePtr& node, const QueryOptions& options) const;
+  inline bool isSubNode(const NodePtr& node) const;
+
+  std::reference_wrapper<const TagNode> root_;
+  std::reference_wrapper<const DOMIndexer> dom_indexer_;
 };
 
 }  // namespace arboris

--- a/src/dom/tag_node.hpp
+++ b/src/dom/tag_node.hpp
@@ -23,8 +23,8 @@ class TagNode final : public BaseNode {
  public:
   static constexpr NodeType kNodeType = NodeType::kTag;
 
-  explicit TagNode(std::uint32_t node_id, HtmlToken&& token, std::shared_ptr<TagNode> parent)
-      : BaseNode(kNodeType, node_id, std::move(parent)), html_token_(std::move(token)) {}
+  explicit TagNode(std::uint32_t node_id, HtmlToken&& token, const std::shared_ptr<TagNode> parent)
+      : BaseNode(kNodeType, node_id, parent), html_token_(std::move(token)) {}
 
   [[nodiscard]] const std::vector<std::shared_ptr<BaseNode>>& children() const noexcept {
     return children_;

--- a/src/dom/tag_node.hpp
+++ b/src/dom/tag_node.hpp
@@ -30,11 +30,11 @@ class TagNode final : public BaseNode {
     return children_;
   }
 
-  [[nodiscard]] const std::unordered_map<std::string, std::string>& attributes() const noexcept {
+  [[nodiscard]] const AttributeMap& attributes() const noexcept {
     return html_token_.attributes;
   }
 
-  [[nodiscard]] const std::unordered_set<std::string>& classes() const noexcept {
+  [[nodiscard]] const ClassSet& classes() const noexcept {
     return html_token_.classes;
   }
 

--- a/src/dom/tag_node.hpp
+++ b/src/dom/tag_node.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -33,7 +34,7 @@ class TagNode final : public BaseNode {
     return html_token_.attributes;
   }
 
-  [[nodiscard]] const std::vector<std::string>& classes() const noexcept {
+  [[nodiscard]] const std::unordered_set<std::string>& classes() const noexcept {
     return html_token_.classes;
   }
 

--- a/src/utils/html_tokens.hpp
+++ b/src/utils/html_tokens.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <vector>
+#include <unordered_set>
 
 #include "utils/tag.hpp"
 #include "utils/tokens.hpp"
@@ -25,7 +25,7 @@ struct HtmlToken : public BaseHtmlToken {
 
   // TODO(team): Consider using string_views with an external string pool
   std::unordered_map<std::string, std::string> attributes;
-  std::vector<std::string> classes;
+  std::unordered_set<std::string> classes;
   std::string id;
 };
 

--- a/src/utils/html_tokens.hpp
+++ b/src/utils/html_tokens.hpp
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -17,6 +18,9 @@
 
 namespace arboris {
 
+using AttributeMap = std::unordered_map<std::string, std::unordered_set<std::string>>;
+using ClassSet = std::unordered_set<std::string>;
+
 struct BaseHtmlToken : public BaseToken {};
 
 struct HtmlToken : public BaseHtmlToken {
@@ -24,8 +28,8 @@ struct HtmlToken : public BaseHtmlToken {
   bool is_void_tag = false;
 
   // TODO(team): Consider using string_views with an external string pool
-  std::unordered_map<std::string, std::string> attributes;
-  std::unordered_set<std::string> classes;
+  AttributeMap attributes;
+  ClassSet classes;
   std::string id;
 };
 

--- a/src/utils/query_options.hpp
+++ b/src/utils/query_options.hpp
@@ -8,13 +8,14 @@
 #define SRC_UTILS_QUERY_OPTIONS_HPP_
 
 #include <optional>
-#include <vector>
+#include <unordered_set>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <functional>
 
 #include "utils/tag.hpp"
+#include "utils/html_tokens.hpp"
 
 namespace arboris {
 
@@ -40,8 +41,8 @@ class TextQueryCondition {
 
 struct QueryOptions {
   std::optional<Tag> tag;
-  std::optional<std::vector<std::string>> classes;
-  std::optional<std::vector<std::pair<std::string, std::string>>> attributes;
+  std::optional<ClassSet> classes;
+  std::optional<AttributeMap> attributes;
   std::optional<TextQueryCondition> text;
 };
 

--- a/src/utils/set_utils.hpp
+++ b/src/utils/set_utils.hpp
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2025 Team Arboris
+ *   Licensed under the Apache License, Version 2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef SRC_UTILS_SET_UTILS_HPP_
+#define SRC_UTILS_SET_UTILS_HPP_
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace arboris {
+
+template <typename T>
+bool IsSubset(const std::unordered_set<T>& subset,
+              const std::unordered_set<T>& super_set) {
+  if (subset.size() > super_set.size()) {
+    return false;
+  }
+
+  for (const auto& x : subset) {
+    // std::unordered_set::contains is available in C++20
+    if (!super_set.contains(x)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T, typename U>
+bool IsSubset(const std::unordered_map<T, std::unordered_set<U>>& subset,
+              const std::unordered_map<T, std::unordered_set<U>>& super_set) {
+  for (const auto& [key, value_set] : subset) {
+    auto it = super_set.find(key);
+    if (it == super_set.end()) {
+      return false;
+    }
+    if (!IsSubset(value_set, it->second)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace arboris
+
+#endif  // SRC_UTILS_SET_UTILS_HPP_


### PR DESCRIPTION
## Implement basic query functionality with cardinality-based index selection

### Changes
- DOMQuery 구현: Find(), FindAll() 메서드 추가
- Cardinality 기반 최적화: 여러 인덱스 중 가장 작은 후보 세트를 선택하여 검색 효율 향상
- 서브트리 체크: in/out 타임스탬프 기반으로 O(1) 서브트리 판정
- SetUtils: 벡터/맵 subset 체크를 위한 헬퍼 함수 추가

### Key Features
- Tag, Class, Attribute 인덱스 중 가장 선택적인(크기가 작은) 것을 자동 선택
- 선택된 후보에 대해서만 나머지 조건 검사로 불필요한 순회 최소화
- 예: tag(1000개) + class(2개) 조건 시 → class로 2개만 가져와서 tag 체크

### TODO
- [ ] DOMIndexer::AddNode에서 class/id/attribute 인덱싱 구현
- [ ] TextQueryCondition 매칭 구현
- [ ] 테스트 케이스 추가

### 불안한 점
- text search 를 함께 사용했을 때 문제가 없는 로직인가?
- indexer 가 attribute 를 저장하고 있는 방식이 정당한가?
- indexer 에서 값을 요청할 때 NodeList 가 만들어지는데, 불필요한 복사가 이루어지지 않는가?
- 모든 DOMQuery instance 가 global index 를 가지고있는 현재 구조는 무결한가?
