### PR TITLE
jack/add-node-key

### DIFF
--- a/src/dom/dom_indexer.cc
+++ b/src/dom/dom_indexer.cc
@@ -16,28 +16,30 @@
 namespace arboris {
 
 void DOMIndexer::AddNode(const NodePtr& node) {
-  tag_index_[node->tag()].emplace_back(node);
-  // TODO(team): add class index
+  tag_index_[node->tag()].emplace_back(node->key());
+  for (const auto& class_name : node->classes()) {
+    class_index_[class_name].emplace_back(node->key());
+  }
   // TODO(team): add id index
 }
 
-NodePtr DOMIndexer::GetNodeById(std::string_view id) const {
+std::optional<NodeKey> DOMIndexer::GetNodeKeyById(std::string_view id) const {
   // TODO(team): consider heterogeneous lookup to avoid std::string allocation
   auto it = id_index_.find(std::string(id));
-  return it != id_index_.end() ? it->second : nullptr;
+  return it != id_index_.end() ? std::make_optional(it->second) : std::nullopt;
 }
 
-std::optional<NodeList> DOMIndexer::GetNodesByTag(Tag tag) const {
+std::optional<NodeKeyList> DOMIndexer::GetNodeKeyListByTag(Tag tag) const {
   auto it = tag_index_.find(tag);
   return it != tag_index_.end() ? std::make_optional(it->second) : std::nullopt;
 }
 
-std::optional<NodeList> DOMIndexer::GetNodesByClass(std::string_view class_name) const {
+std::optional<NodeKeyList> DOMIndexer::GetNodeKeyListByClass(std::string_view class_name) const {
   auto it = class_index_.find(std::string(class_name));
   return it != class_index_.end() ? std::make_optional(it->second) : std::nullopt;
 }
 
-std::optional<NodeList> DOMIndexer::GetNodesByAttribute(std::string_view attribute_name) const {
+std::optional<NodeKeyList> DOMIndexer::GetNodeKeyListByAttribute(std::string_view attribute_name) const {
   auto it = attr_index_.find(std::string(attribute_name));
   return it != attr_index_.end() ? std::make_optional(it->second) : std::nullopt;
 }

--- a/src/dom/dom_indexer.hpp
+++ b/src/dom/dom_indexer.hpp
@@ -27,19 +27,19 @@ class DOMIndexer {
 
   void AddNode(const NodePtr& node);
 
-  [[nodiscard]] NodePtr GetNodeById(std::string_view id) const;
-  [[nodiscard]] std::optional<NodeList> GetNodesByTag(Tag tag) const;
-  [[nodiscard]] std::optional<NodeList> GetNodesByClass(std::string_view class_name) const;
-  [[nodiscard]] std::optional<NodeList> GetNodesByAttribute(std::string_view attribute_name) const;
+  [[nodiscard]] std::optional<NodeKey> GetNodeKeyById(std::string_view id) const;
+  [[nodiscard]] std::optional<NodeKeyList> GetNodeKeyListByTag(Tag tag) const;
+  [[nodiscard]] std::optional<NodeKeyList> GetNodeKeyListByClass(std::string_view class_name) const;
+  [[nodiscard]] std::optional<NodeKeyList> GetNodeKeyListByAttribute(std::string_view attribute_name) const;
 
  private:
   // TODO(team): consider using std::list instead of std::vector for indexes
-  std::unordered_map<std::string, NodePtr> id_index_;
-  std::unordered_map<Tag, NodeList> tag_index_;
-  std::unordered_map<std::string, NodeList> class_index_;
+  std::unordered_map<std::string, NodeKey> id_index_;
+  std::unordered_map<Tag, NodeKeyList> tag_index_;
+  std::unordered_map<std::string, NodeKeyList> class_index_;
 
   // TODO(team): consider indexing by value instead of name
-  std::unordered_map<std::string, NodeList> attr_index_;
+  std::unordered_map<std::string, NodeKeyList> attr_index_;
 };
 
 }  // namespace arboris

--- a/src/dom/dom_indexer.hpp
+++ b/src/dom/dom_indexer.hpp
@@ -25,6 +25,7 @@ class DOMIndexer {
   DOMIndexer& operator=(DOMIndexer&&) = delete;
   virtual ~DOMIndexer() = default;
 
+  // TODO(team): avoid using const reference for NodePtr
   void AddNode(const NodePtr& node);
 
   [[nodiscard]] std::optional<NodeKey> GetNodeKeyById(std::string_view id) const;

--- a/src/dom/dom_types.hpp
+++ b/src/dom/dom_types.hpp
@@ -14,6 +14,8 @@ namespace arboris {
 
 class TagNode;
 
+using NodeKey = std::uint32_t;
+using NodeKeyList = std::vector<NodeKey>;
 using NodePtr = std::shared_ptr<TagNode>;
 using NodeList = std::vector<NodePtr>;
 

--- a/src/dom/tag_node.hpp
+++ b/src/dom/tag_node.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "dom/dom_types.hpp"
 #include "dom/base_node.hpp"
 #include "utils/html_tokens.hpp"
 
@@ -40,6 +41,10 @@ class TagNode final : public BaseNode {
 
   [[nodiscard]] std::string_view id() const noexcept {
     return html_token_.id;
+  }
+
+  [[nodiscard]] NodeKey key() const noexcept {
+    return html_token_.begin_pos;
   }
 
   [[nodiscard]] Tag tag() const noexcept {

--- a/src/dom/tag_node.hpp
+++ b/src/dom/tag_node.hpp
@@ -14,8 +14,8 @@
 #include <utility>
 #include <vector>
 
-#include "dom/dom_types.hpp"
 #include "dom/base_node.hpp"
+#include "dom/dom_types.hpp"
 #include "utils/html_tokens.hpp"
 
 namespace arboris {
@@ -27,29 +27,17 @@ class TagNode final : public BaseNode {
   explicit TagNode(std::uint32_t node_id, HtmlToken&& token, const std::shared_ptr<TagNode> parent)
       : BaseNode(kNodeType, node_id, parent), html_token_(std::move(token)) {}
 
-  [[nodiscard]] const std::vector<std::shared_ptr<BaseNode>>& children() const noexcept {
-    return children_;
-  }
+  [[nodiscard]] const std::vector<std::shared_ptr<BaseNode>>& children() const noexcept { return children_; }
 
-  [[nodiscard]] const AttributeMap& attributes() const noexcept {
-    return html_token_.attributes;
-  }
+  [[nodiscard]] const AttributeMap& attributes() const noexcept { return html_token_.attributes; }
 
-  [[nodiscard]] const ClassSet& classes() const noexcept {
-    return html_token_.classes;
-  }
+  [[nodiscard]] const ClassSet& classes() const noexcept { return html_token_.classes; }
 
-  [[nodiscard]] std::string_view id() const noexcept {
-    return html_token_.id;
-  }
+  [[nodiscard]] std::string_view id() const noexcept { return html_token_.id; }
 
-  [[nodiscard]] NodeKey key() const noexcept {
-    return html_token_.begin_pos;
-  }
+  [[nodiscard]] NodeKey key() const noexcept { return in(); }
 
-  [[nodiscard]] Tag tag() const noexcept {
-    return html_token_.tag;
-  }
+  [[nodiscard]] Tag tag() const noexcept { return html_token_.tag; }
 
   void AddChild(std::shared_ptr<BaseNode> child) {
     ARBORIS_ASSERT(child != nullptr, "child must not be nullptr.");

--- a/src/dom/tag_node.hpp
+++ b/src/dom/tag_node.hpp
@@ -14,8 +14,8 @@
 #include <utility>
 #include <vector>
 
-#include "dom/base_node.hpp"
 #include "dom/dom_types.hpp"
+#include "dom/base_node.hpp"
 #include "utils/html_tokens.hpp"
 
 namespace arboris {
@@ -27,17 +27,29 @@ class TagNode final : public BaseNode {
   explicit TagNode(std::uint32_t node_id, HtmlToken&& token, const std::shared_ptr<TagNode> parent)
       : BaseNode(kNodeType, node_id, parent), html_token_(std::move(token)) {}
 
-  [[nodiscard]] const std::vector<std::shared_ptr<BaseNode>>& children() const noexcept { return children_; }
+  [[nodiscard]] const std::vector<std::shared_ptr<BaseNode>>& children() const noexcept {
+    return children_;
+  }
 
-  [[nodiscard]] const AttributeMap& attributes() const noexcept { return html_token_.attributes; }
+  [[nodiscard]] const AttributeMap& attributes() const noexcept {
+    return html_token_.attributes;
+  }
 
-  [[nodiscard]] const ClassSet& classes() const noexcept { return html_token_.classes; }
+  [[nodiscard]] const ClassSet& classes() const noexcept {
+    return html_token_.classes;
+  }
 
-  [[nodiscard]] std::string_view id() const noexcept { return html_token_.id; }
+  [[nodiscard]] std::string_view id() const noexcept {
+    return html_token_.id;
+  }
 
-  [[nodiscard]] NodeKey key() const noexcept { return in(); }
+  [[nodiscard]] NodeKey key() const noexcept {
+    return in();
+  }
 
-  [[nodiscard]] Tag tag() const noexcept { return html_token_.tag; }
+  [[nodiscard]] Tag tag() const noexcept {
+    return html_token_.tag;
+  }
 
   void AddChild(std::shared_ptr<BaseNode> child) {
     ARBORIS_ASSERT(child != nullptr, "child must not be nullptr.");


### PR DESCRIPTION
refactor: update DOMIndexer to use NodeKey for indexing and improve lookup methods
  - Changed AddNode to store NodeKey instead of NodePtr for better indexing.
  - Updated retrieval methods to return NodeKey and NodeKeyList, enhancing type safety and performance.
  - Introduced key() method in TagNode for accessing NodeKey, streamlining node management.